### PR TITLE
Enabled single conversation option for API channels.

### DIFF
--- a/app/builders/conversation_builder.rb
+++ b/app/builders/conversation_builder.rb
@@ -9,9 +9,14 @@ class ConversationBuilder
 
   def look_up_exising_conversation
     return unless @contact_inbox.inbox.lock_to_single_conversation?
-
-    @contact_inbox.conversations.last
+    conversation = @contact_inbox.conversations.where(status: 'open').last
+    if conversation.nil?
+      conversation = @contact_inbox.conversations.order(updated_at: :desc).first
+    end
+    conversation.update(status: 'open') if conversation.present?
+    conversation
   end
+
 
   def create_new_conversation
     ::Conversation.create!(conversation_params)

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -193,7 +193,7 @@ export default {
     },
     canLocktoSingleConversation() {
       return (
-        this.isASmsInbox || this.isAWhatsAppChannel || this.isAFacebookInbox
+        this.isASmsInbox || this.isAWhatsAppChannel || this.isAFacebookInbox || this.isAPIInbox
       );
     },
     inboxNameLabel() {


### PR DESCRIPTION
When enabling this option, the message will be created in the current open conversation, if there is no open conversation or multiple open conversations, it will be created in the conversation that had the last iteration.