### PR TITLE
Fix: Chats shown for agents even with 'hide_all_chats_for_agent' enabled.

### DIFF
--- a/app/javascript/dashboard/components/ChatList.vue
+++ b/app/javascript/dashboard/components/ChatList.vue
@@ -287,7 +287,7 @@ export default {
       ).map(({ key, count: countKey }) => ({
         key,
         name: this.$t(`CHAT_LIST.ASSIGNEE_TYPE_TABS.${key}`),
-        count: this.conversationStats[countKey] || 0,
+        count: this.hideAllChatsForAgents && this.currentRole !== 'administrator' ? 0 : this.conversationStats[countKey] || 0,
       }));
     },
     showAssigneeInConversationCard() {
@@ -385,6 +385,10 @@ export default {
     },
     conversationList() {
       let conversationList = [];
+      if (this.hideAllChatsForAgents && this.currentRole !== 'administrator') {
+        !this.chatListLoading;
+        return [];
+      }
       if (!this.hasAppliedFiltersOrActiveFolders) {
         const filters = this.conversationFilters;
         if (this.activeAssigneeTab === 'me') {


### PR DESCRIPTION
The ChatList.vue component didn't had a function to verify if the current user wasn't an 'administrator' and if the current company had the flag 'hide_all_chats_for_agent' set to true to prevend rendering chats for agent users.

Two changes were made to make it work as intended.

# 1: The value of count which is responsible to show the chat counts on the tabs now displays always 0 if the user isn't 'administrator' and the current account has the flag 'hide_all_chats_for_agent' set to true.

`assigneeTabItems() {
      return filterItemsByPermission(
        ASSIGNEE_TYPE_TAB_PERMISSIONS,
        this.userPermissions,
        item => item.permissions
      ).map(({ key, count: countKey }) => ({
        key,
        name: this.$t(`CHAT_LIST.ASSIGNEE_TYPE_TABS.${key}`),
        count: this.hideAllChatsForAgents && this.currentRole !== 'administrator' ? 0 : this.conversationStats[countKey] || 0,
      }));
    },`

# 2: The function that creates the chat list now returns an empty array if the user isn't 'administrator' and the current account has the flag 'hide_all_chats_for_agent' set to true.

`conversationList() {
      let conversationList = [];
      if (this.hideAllChatsForAgents && this.currentRole !== 'administrator') {
        !this.chatListLoading;
        return [];
      }
      if (!this.hasAppliedFiltersOrActiveFolders) {
        const filters = this.conversationFilters;
        if (this.activeAssigneeTab === 'me') {
          conversationList = [...this.mineChatsList(filters)];
        } else if (this.activeAssigneeTab === 'unassigned') {
          conversationList = [...this.unAssignedChatsList(filters)];
        } else {
          conversationList = [...this.allChatList(filters)];
        }
      } else {
        conversationList = [...this.chatLists];
      }
      return conversationList;
    },`
    