### PR TITLE
Restringe o acesso a conversas e mensagens aos usuários relacionados

### DIFF
--- a/app/controllers/api/v1/accounts/contacts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts/conversations_controller.rb
@@ -1,8 +1,11 @@
 class Api::V1::Accounts::Contacts::ConversationsController < Api::V1::Accounts::Contacts::BaseController
   def index
-    @conversations = Current.account.conversations.includes(
-      :assignee, :contact, :inbox, :taggings
-    ).where(inbox_id: inbox_ids, contact_id: @contact.id).order(id: :desc).limit(20)
+    @conversations = @contact.conversations.where(account_id: current_account.id)
+
+    unless Current.user.administrator?
+      @conversations = @conversations.accessible_by_user(Current.user)
+    end
+
   end
 
   private

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -70,7 +70,15 @@ class Conversation < ApplicationRecord
 
   enum status: { open: 0, resolved: 1, pending: 2, snoozed: 3 }
   enum priority: { low: 0, medium: 1, high: 2, urgent: 3 }
-
+  
+  scope :accessible_by_user, ->(user) {
+    left_outer_joins(:conversation_participants)
+      .where(
+        'conversations.assignee_id = :user_id OR conversation_participants.user_id = :user_id',
+        user_id: user.id
+      ).distinct
+  }
+  
   scope :unassigned, -> { where(assignee_id: nil) }
   scope :assigned, -> { where.not(assignee_id: nil) }
   scope :assigned_to, ->(agent) { where(assignee_id: agent.id) }


### PR DESCRIPTION
- Modifica filter_conversations para retornar conversas onde o usuário é o responsável (assignee_id) ou participante através de conversation_participants.
- Ajusta filter_messages para retornar mensagens enviadas pelo agente, mensagens em conversas onde o agente participa ou está atribuído, e mensagens enviadas por contatos em conversas onde o agente participa.
- Modifica a API no backend do Chatwoot para aplicar essas restrições no nível do servidor, garantindo que apenas conversas relevantes sejam retornadas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced filtering for conversations and messages based on user roles, improving access control.
	- Introduced a new method to retrieve conversations accessible to users based on their participation.

- **Bug Fixes**
	- Adjusted conversation retrieval logic to ensure users only see conversations they are permitted to access.

- **Refactor**
	- Improved the logic in the search service for better performance and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->