### PR TITLE
fix: parsing of @ in i18n values

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/login.json
+++ b/app/javascript/dashboard/i18n/locale/en/login.json
@@ -3,7 +3,7 @@
     "TITLE": "Login to Chatwoot",
     "EMAIL": {
       "LABEL": "Email",
-      "PLACEHOLDER": "example@companyname.com",
+      "PLACEHOLDER": "example{'@'}companyname.com",
       "ERROR": "Please enter a valid email address"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/en/signup.json
+++ b/app/javascript/dashboard/i18n/locale/en/signup.json
@@ -20,7 +20,7 @@
     },
     "EMAIL": {
       "LABEL": "Work email",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce@wayne.enterprises",
+      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne.enterprises",
       "ERROR": "Please enter a valid work email address."
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/es/login.json
+++ b/app/javascript/dashboard/i18n/locale/es/login.json
@@ -3,7 +3,7 @@
     "TITLE": "Iniciar sesión en Chatwoot",
     "EMAIL": {
       "LABEL": "Correo electrónico",
-      "PLACEHOLDER": "example@companyname.com",
+      "PLACEHOLDER": "example{'@'}companyname.com",
       "ERROR": "Por favor, introduce una dirección de correo electrónico válida"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/es/signup.json
+++ b/app/javascript/dashboard/i18n/locale/es/signup.json
@@ -20,7 +20,7 @@
     },
     "EMAIL": {
       "LABEL": "Correo electrónico de trabajo",
-      "PLACEHOLDER": "Ingresa tu dirección de correo electrónico de trabajo. Ej., bruce@wayne.enterprises",
+      "PLACEHOLDER": "Ingresa tu dirección de correo electrónico de trabajo. Ej., bruce{'@'}wayne.enterprises",
       "ERROR": "Por favor, ingresa una dirección de correo electrónico de trabajo válida."
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/pt/login.json
+++ b/app/javascript/dashboard/i18n/locale/pt/login.json
@@ -3,7 +3,7 @@
     "TITLE": "Login to Chatwoot",
     "EMAIL": {
       "LABEL": "Email",
-      "PLACEHOLDER": "example@companyname.com",
+      "PLACEHOLDER": "example{'@'}companyname.com",
       "ERROR": "Por favor, insira um endereço de email válido"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/pt/signup.json
+++ b/app/javascript/dashboard/i18n/locale/pt/signup.json
@@ -20,7 +20,7 @@
     },
     "EMAIL": {
       "LABEL": "Email de trabalho",
-      "PLACEHOLDER": "Insira o seu endereço de email de trabalho. Ex., bruce@wayne.enterprises",
+      "PLACEHOLDER": "Insira o seu endereço de email de trabalho. Ex., bruce{'@'}wayne.enterprises",
       "ERROR": "Por favor, insira um endereço de email de trabalho válido."
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/pt_BR/login.json
+++ b/app/javascript/dashboard/i18n/locale/pt_BR/login.json
@@ -3,7 +3,7 @@
     "TITLE": "Login to Chatwoot",
     "EMAIL": {
       "LABEL": "Email",
-      "PLACEHOLDER": "example@companyname.com",
+      "PLACEHOLDER": "example{'@'}companyname.com",
       "ERROR": "Por favor, insira um endereço de email válido"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/pt_BR/signup.json
+++ b/app/javascript/dashboard/i18n/locale/pt_BR/signup.json
@@ -20,7 +20,7 @@
     },
     "EMAIL": {
       "LABEL": "Email de trabalho",
-      "PLACEHOLDER": "Digite seu endereço de email de trabalho. Ex., bruce@wayne.enterprises",
+      "PLACEHOLDER": "Digite seu endereço de email de trabalho. Ex., bruce{'@'}wayne.enterprises",
       "ERROR": "Por favor, insira um endereço de email de trabalho válido."
     },
     "PASSWORD": {


### PR DESCRIPTION
Vue i18n has a new [linked message syntax.](https://vue-i18n.intlify.dev/guide/essentials/syntax.html#linked-messages)
When it encounters @ it assumes that we're trying to use a linked message. And tries to parse it as such, in any case, it breaks since the syntax is not valid and the params are not present. So it causes an error. This works on dev but on production the error is bubbled up to the top and rendering breaks.

A lot of folks use Chatwoot with default locale set in the env, this surfaced the issue for the languages for which the syntax was not updated

Fixes: https://github.com/chatwoot/chatwoot/issues/10313
Pull: https://github.com/chatwoot/chatwoot/pull/10334